### PR TITLE
JayDeBeApi (Python DB-API) Sample for GridDB JDBC Driver

### DIFF
--- a/sample/en/jdbc/python-db-api/DBAPISelect.py
+++ b/sample/en/jdbc/python-db-api/DBAPISelect.py
@@ -1,0 +1,28 @@
+import jaydebeapi
+import sys
+
+argv = sys.argv
+
+multicast_address = argv[1] # default : 239.0.0.1
+port_no = argv[2] # default : 41999
+cluster_name = argv[3]
+username = argv[4]
+password = argv[5]
+
+url = "jdbc:gs://" + multicast_address + ":" + port_no + "/" + cluster_name
+conn = jaydebeapi.connect("com.toshiba.mwcloud.gs.sql.Driver",
+    url, [username, password], "./gridstore-jdbc.jar")
+
+curs = conn.cursor()
+
+curs.execute("DROP TABLE IF EXISTS Sample")
+curs.execute("CREATE TABLE IF NOT EXISTS Sample ( id integer PRIMARY KEY, value string )")
+print('SQL Create Table name=Sample')
+curs.execute("INSERT INTO Sample values (0, 'test0'),(1, 'test1'),(2, 'test2'),(3, 'test3'),(4, 'test4')")
+print('SQL Insert')
+curs.execute("SELECT * from Sample where ID > 2")
+print(curs.fetchall())
+
+curs.close()
+conn.close()
+print('success!')

--- a/sample/en/jdbc/python-db-api/README.md
+++ b/sample/en/jdbc/python-db-api/README.md
@@ -1,0 +1,21 @@
+[JayDeBeApi](https://pypi.org/project/JayDeBeApi/) ([Python DB-API](https://www.python.org/dev/peps/pep-0249/)) Sample for GridDB JDBC Driver
+
+# Operating environment
+
+Python==3.6  
+JayDeBeApi==1.2.3  
+JPype1==0.6.3
+
+    $ pip install JayDeBeApi
+    $ pip install JPype1==0.6.3
+
+# Execute a sample program
+
+GridDB server need to be started in advance with multicast method.
+
+    $ mvn dependency:get -Dartifact=com.github.griddb:gridstore-jdbc:4.5.0.1 -Ddest=./gridstore-jdbc.jar
+    $ python DBAPISelect.py <multicast_address> <port_no> <cluster_name> <username> <password>
+    SQL Create Table name=Sample
+    SQL Insert
+    [(3, 'test3'), (4, 'test4')]
+    success!


### PR DESCRIPTION
[JayDeBeApi](https://pypi.org/project/JayDeBeApi/) ([Python DB-API](https://www.python.org/dev/peps/pep-0249/)) Sample for GridDB JDBC Driver

# Operating environment

Python==3.6
JayDeBeApi==1.2.3
JPype1==0.6.3

    $ pip install JayDeBeApi
    $ pip install JPype1==0.6.3

# Execute a sample program

GridDB server need to be started in advance with multicast method.

    $ mvn dependency:get -Dartifact=com.github.griddb:gridstore-jdbc:4.5.0.1 -Ddest=./gridstore-jdbc.jar
    $ python DBAPISelect.py <multicast_address> <port_no> <cluster_name> <username> <password>
    SQL Create Table name=Sample
    SQL Insert
    [(3, 'test3'), (4, 'test4')]
    success!